### PR TITLE
API: rename Team endpoint paths from sites to teams; base.html points to wrong css file

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -24,7 +24,7 @@ schema_view = get_schema_view(
 '''
 
 router = SimpleRouter()
-router.register(r'sites', SiteViewSet, base_name='sites')
+router.register(r'teams', SiteViewSet, base_name='teams')
 # urlpatterns = router.urls
 
 # The API URLs are now determined automatically by the router.

--- a/european_football/templates/european_football/base.html
+++ b/european_football/templates/european_football/base.html
@@ -14,7 +14,7 @@
           integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm"
           crossorigin="anonymous">
 
-    <link rel="stylesheet" href="{% static 'css/heritagesites.css' %}">
+    <link rel="stylesheet" href="{% static 'css/european_football.css' %}">
 
     <title>{% block title %}European Football App{% endblock title %}</title>
   </head>


### PR DESCRIPTION
This PR corrects the following errors:

* changes the path resource name from `sites` to `teams` in order to render the endpoint comprehensible to the user.
* repoints `base.html` to the correct css file.

### Original view encountered

![image](https://user-images.githubusercontent.com/83268/50385291-8016f400-06a1-11e9-9590-de4e8f661951.png)
